### PR TITLE
CMS 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
     "name": "silverstripe/superglue",
     "type": "silverstripe-vendormodule",
     "require": {
-        "silverstripe/cms": "^4.0",
-        "silverstripe/framework": "^4.0",
-        "silverstripe-australia/gridfieldextensions": "^3.0"
+        "silverstripe/cms": "^5.1",
+        "silverstripe/framework": "^5.1",
+        "symbiote/silverstripe-gridfieldextensions": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -22,7 +22,7 @@
         ]
     },
     "branch-alias": {
-        "dev-master": "1.x-dev"
+        "dev-master": "0.1.x-dev"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
# CMS 5 upgrade
- removed abandoned `silverstripe-australia/gridfieldextensions` and replaced with `symbiote/silverstripe-gridfieldextensions`
- framework and cms carrotted to `5.1`
- removed redundant alias for `dev-master` and changed to `0.1.x-dev` so alias is correct to `0.1` branch

Tested on framework`5.1.0`